### PR TITLE
bugfix/accurics_remediation_9972463229669735 - Auto Generated Pull Request From Accurics

### DIFF
--- a/terraform/aws/modules/network/main.tf
+++ b/terraform/aws/modules/network/main.tf
@@ -44,7 +44,7 @@ resource "aws_subnet" "km_public_subnet" {
   cidr_block              = cidrsubnet(aws_vpc.km_vpc.cidr_block, 8, var.az_count + count.index)
   availability_zone       = data.aws_availability_zones.available.names[count.index]
   vpc_id                  = aws_vpc.km_vpc.id
-  map_public_ip_on_launch = true
+  map_public_ip_on_launch = false
 
   tags = merge(var.default_tags, {
     Name = "km_public_subnet_${var.environment}"
@@ -165,7 +165,7 @@ resource "aws_lb_target_group" "km_lb_target" {
   protocol    = "HTTP"
   vpc_id      = aws_vpc.km_vpc.id
   target_type = "ip"
-  depends_on = [ aws_lb.km_lb ]
+  depends_on  = [aws_lb.km_lb]
 }
 
 # Redirect all traffic from the ALB to the target group


### PR DESCRIPTION
All subnets have an attribute that determines whether a network interface created in the subnet automatically receives a public IPv4 address. Therefore, it is recommended to set ot to FALSE. In AWS Console - 
 1. Sign in to the AWS Console and go to the VPC dashboard.
 2. In the navigation pane, select subnets.
 3. Select your subnet and then choose Subnet Actions, Modify auto-assign IP settings.
 4. Clear the Enable auto-assign public IPv4 address check box and then choose Save.
 In terraform - Modify 'aws_subnet' resource and set 'map_public_ip_on_launch' to false.