### PR TITLE
bugfix/accurics_remediation_8906426075061664 - Auto Generated Pull Request From Accurics

### DIFF
--- a/terraform/aws/modules/storage/main.tf
+++ b/terraform/aws/modules/storage/main.tf
@@ -111,6 +111,10 @@ resource "aws_s3_bucket" "km_blob_storage" {
 
 resource "aws_s3_bucket" "km_public_blob" {
   bucket = "km-public-blob"
+
+  versioning {
+    enabled = true
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "km_public_blob" {


### PR DESCRIPTION
In AWS Console - 
1. Log into the AWS Management Console.
2. Select the 'Services' option and search for S3.
3. Scroll down the left navigation panel and choose 'Buckets'.
4. Select the 'Bucket' that needs to be verified and click on its identifier(name) from the 'Bucket name' column.
5. Click on the 'Properties' tab on the top menu.
6. Check the 'Versioning' option under 'Properties' and if it's set to 'Suspend versioning' then S3 bucket versioning is not enabled for the selected S3 bucket.
7. Repeat steps number 2 - 6 to verify other S3 buckets in the region.
8. Select the 'S3 bucket' on which versioning needs to be enabled and click on the 'Properties' tab.
9. Click on the 'Enable versioning' option under 'Versioning'.
10. Click 'Save'.

In Terraform -
Current AWS Provider versions:
1. For each aws_s3_bucket resource, create an aws_s3_bucket_versioning resource in accordance with the requirements outlined in the Terraform documentation.

AWS Provider versions prior to 3.x (field is deprecated starting in version 3.x):
1. In the aws_s3_bucket, set the 'versioning.enabled' attribute to 'true'.

References:
[https://docs.aws.amazon.com/AmazonS3/latest/userguide/manage-versioning-examples.html](https://docs.aws.amazon.com/AmazonS3/latest/userguide/manage-versioning-examples.html)
[https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning)
[https://registry.terraform.io/providers/hashicorp/aws/2.70.4/docs/resources/s3_bucket#versioning](https://registry.terraform.io/providers/hashicorp/aws/2.70.4/docs/resources/s3_bucket#versioning)